### PR TITLE
Fixing FFMpeg screen capturing on linux

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,23 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ "linuxbuild" ]
+  pull_request:
+    branches: [ "linuxbuild" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: configure
+      run: ./configure
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+    - name: make distcheck
+      run: make distcheck

--- a/Server/CMakeLists.txt
+++ b/Server/CMakeLists.txt
@@ -75,7 +75,7 @@ target_link_libraries(AudioGridderServer PRIVATE
   ${SENTRY_LIBRARIES})
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  target_link_libraries(AudioGridderServer PRIVATE  X11 Xtst)
+  target_link_libraries(AudioGridderServer PRIVATE  X11 Xtst xcb xcb-shm xcb-xfixes xcb-shape)
   target_compile_definitions(AudioGridderServer PRIVATE JUCE_LINUX=1)
 endif()
 

--- a/Server/Source/ScreenRecorder.cpp
+++ b/Server/Source/ScreenRecorder.cpp
@@ -87,6 +87,9 @@ void ScreenRecorder::initialize(ScreenRecorder::EncoderMode encMode, EncoderQual
     askForScreenRecordingPermission();
     m_inputFmtName = "avfoundation";
     m_inputStreamUrl = String(getCaptureDeviceIndex()) + ":none";
+#elif defined JUCE_LINUX
+    m_inputFmtName = "x11grab";
+    m_inputStreamUrl = ":0.0";
 #else
     m_inputFmtName = "gdigrab";
     m_inputStreamUrl = "desktop";
@@ -291,11 +294,14 @@ bool ScreenRecorder::prepareInput() {
 #endif
 
     int ret;
-
-    logln("opening input format " << m_inputFmtName << ": " << m_inputStreamUrl);
+    String streamUrl = m_inputStreamUrl;
+#ifdef JUCE_LINUX
+    streamUrl = streamUrl << "+" << m_captureRect.getX() << "," << m_captureRect.getY();
+#endif
+    logln("opening input format " << m_inputFmtName << ": " << streamUrl);
 
     m_captureFmtCtx = avformat_alloc_context();
-    ret = avformat_open_input(&m_captureFmtCtx, m_inputStreamUrl.getCharPointer(), m_inputFmt, &opts);
+    ret = avformat_open_input(&m_captureFmtCtx, streamUrl.getCharPointer(), m_inputFmt, &opts);
     if (ret != 0) {
         logError("prepareInput: avformat_open_input failed: err = " + String(ret));
         return false;

--- a/Server/Source/Server.hpp
+++ b/Server/Source/Server.hpp
@@ -156,16 +156,15 @@ class Server : public Thread, public LogTag {
     bool m_enableVST2 = true;
     float m_screenJpgQuality = 0.9f;
     bool m_screenDiffDetection = true;
+    bool m_screenCapturingFFmpeg = true;
     bool m_screenCapturingOff = false;
     bool m_screenLocalMode = false;
     int m_screenMouseOffsetX = 0;
     int m_screenMouseOffsetY = 0;
 #ifdef JUCE_LINUX
     bool m_pluginWindowsOnTop = true;
-    bool m_screenCapturingFFmpeg = false;
 #else
     bool m_pluginWindowsOnTop = false;
-    bool m_screenCapturingFFmpeg = true;
 #endif
     ScreenRecorder::EncoderMode m_screenCapturingFFmpegEncMode = ScreenRecorder::WEBP;
     ScreenRecorder::EncoderQuality m_screenCapturingFFmpegQuality = ScreenRecorder::ENC_QUALITY_MEDIUM;


### PR DESCRIPTION
This fixes the FFMpeg Screen capturing functionality of linux.
Compile FFMpeg Libs with --enable-libxcb option 